### PR TITLE
fix for os.h issue on ubuntu 15.10

### DIFF
--- a/src/synproto.h
+++ b/src/synproto.h
@@ -30,7 +30,8 @@
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
-
+ 
+#include <xorg-server.h>
 #include <unistd.h>
 #include <sys/ioctl.h>
 #include <xf86Xinput.h>


### PR DESCRIPTION
This is a fix for the bug: 

/usr/include/xorg/os.h:541:1: error: expected identifier or '(' before '**extension**'
 strndup(const char *str, size_t n);
 ^

As described here http://lists.x.org/archives/xorg-devel/2014-July/043067.html and http://www.phoronix.com/forums/forum/linux-graphics-x-org-drivers/open-source-amd-linux/49002-dri3-support-finally-added-to-amd-s-radeon-x-org-driver/page3

This enables successful compilation on ubuntu 15.10
